### PR TITLE
fix: _write_definitions Permission denied

### DIFF
--- a/pv_visualizer/app/engine/proxymanager/core.py
+++ b/pv_visualizer/app/engine/proxymanager/core.py
@@ -359,9 +359,13 @@ class ParaviewProxyManager:
             Path(self._write_definitions_base)
             / f"{'/'.join(proxy_type.split('__'))}.{extension}"
         )
-        os.makedirs(file_name.parent, exist_ok=True)
-        with open(file_name, "w") as file:
-            file.write(content)
+
+        try:
+            os.makedirs(file_name.parent, exist_ok=True)
+            with open(file_name, "w") as file:
+                file.write(content)
+        except PermissionError:  # Write-protection
+            pass
 
     def _proxy_ensure_definition(self, proxy):
         proxy_type = definitions.proxy_type(proxy)


### PR DESCRIPTION
When using pv_visualizer from a global installation or another user, `_write_definitions` will cause `PermissionError: [Errno 13] Permission denied`, because it's trying to write to `/app/engine/proxymanager/definitions` and the user might not have the permissions to do so.

A try-except should prevent the app from crashing if it encounters that problem. Since it is marked as debugging, I figured just skipping the writing should be fine.