### PR TITLE
Changed _update_path() parameters and parsing dict inside the function

### DIFF
--- a/pv_visualizer/html/file_browser.py
+++ b/pv_visualizer/html/file_browser.py
@@ -173,7 +173,7 @@ class AbstractFileBrowser(ListBrowser):
         super().__init__(
             list=(self._key_listing, []),
             path=(self._key_path, []),
-            click=(self._update_path, "[]", "$event"),
+            click=(self._update_path, "[$event]"),
             **kwargs,
         )
         # "path_icon",
@@ -228,7 +228,9 @@ class AbstractFileBrowser(ListBrowser):
 
         self.server.state[self._key_listing] = listing
 
-    def _update_path(self, type, value):
+    def _update_path(self, fileinfo):
+        type = fileinfo["type"]
+        value = fileinfo["value"]
         if type == "Directory":
             current_path = self.server.state[self._key_path]
             new_path = []


### PR DESCRIPTION
HI,
There was a Bug in this Trame based ParaView-Visualizer that it was not able to read any file from data directory. It was throwing the following error when we click to load any file from Data directory:

![9feabe7af9d039a8b510e6f0771ffcd5f109fd71](https://user-images.githubusercontent.com/49350815/219573155-e2a7b27b-fc1f-4b4e-b643-a25537ef70bb.png)
![b293a485668b97ae27f2fb62c4117d42ab3a0fbd](https://user-images.githubusercontent.com/49350815/219573166-8b48f050-2cff-4512-b194-3185bb758d13.png)

According to Error, it seems that `_update_path() ` method was triggered with incomplete arguments because of this the `type ` was considered a unexpected keyword argument.
I simple changed the parameters of `_update_path() ` method and passed only `$event` as arguments from where this method was triggered and it received a `dict` .  In method body, parsed dict and assigned values to the `type ` and `value`.

Now it is working, it tested with the following files:

- Basic ParaView Examples files like `bake.e` , `ge.vtk ` etc.
- Custom Reader for reading .db extension files.

Regards,
Ans