### PR TITLE
fix(logging): Wrong number of arguments

### DIFF
--- a/pv_visualizer/app/engine/proxymanager/core.py
+++ b/pv_visualizer/app/engine/proxymanager/core.py
@@ -153,13 +153,11 @@ class ParaViewProxyObjectAdapter(ProxyObjectAdapter):
     def before_delete(simput_proxy):
         pv_proxy = simput_proxy.object
         logger.info(
-            "Deleting PV proxy",
+            "Deleting PV proxy: %s -> %s",
             simput_proxy.id,
-            pv_proxy.GetGlobalIDAsString(),
-            pv_proxy.GetReferenceCount(),
+            pv_proxy.GetGlobalIDAsString()
         )
         simple.Delete(pv_proxy)
-        logger.info("simple.Delete() => done", pv_proxy.GetReferenceCount())
 
 
 # -----------------------------------------------------------------------------

--- a/pv_visualizer/app/engine/proxymanager/core.py
+++ b/pv_visualizer/app/engine/proxymanager/core.py
@@ -155,7 +155,7 @@ class ParaViewProxyObjectAdapter(ProxyObjectAdapter):
         logger.info(
             "Deleting PV proxy: %s -> %s",
             simput_proxy.id,
-            pv_proxy.GetGlobalIDAsString()
+            pv_proxy.GetGlobalIDAsString(),
         )
         simple.Delete(pv_proxy)
 


### PR DESCRIPTION
When shutting down the App, you get a bunch of Exceptions because of the mismatch of the number of Arguments passed to the logger.

Is there a reason all the other logging calls in the Adapter are commented out? If we don't need this log, we can also comment it out.